### PR TITLE
add documention about where to download data

### DIFF
--- a/notebooks/ntl-analysis/01_clean_gas_flaring_data.R
+++ b/notebooks/ntl-analysis/01_clean_gas_flaring_data.R
@@ -1,6 +1,7 @@
 # Clean Gas Flaring Data
 
 # Create dataset of gas flaring locations in Syria
+# Raw data from: https://datacatalog.worldbank.org/search/dataset/0037743
 
 # Load data --------------------------------------------------------------------
 clean_data <- function(x) x %>% clean_names() %>% dplyr::filter(iso_code %in% "SYR")

--- a/notebooks/ntl-analysis/02_map_ntl_latest.R
+++ b/notebooks/ntl-analysis/02_map_ntl_latest.R
@@ -2,7 +2,7 @@
 
 # Load data --------------------------------------------------------------------
 r_mean  <- raster(file.path(data_dir, "bm_vnp46A3_2022_08.tif"))
-gadm_sp <- readRDS(file.path(data_dir, "gadm36_SYR_0_sp.rds"))
+gadm_sp <- getData('GADM', country='SYR', level=0) 
 
 # Prep data --------------------------------------------------------------------
 r_mean <- r_mean %>% crop(gadm_sp) %>% mask(gadm_sp) 

--- a/notebooks/ntl-analysis/02_maps_of_ntl_changes.R
+++ b/notebooks/ntl-analysis/02_maps_of_ntl_changes.R
@@ -2,7 +2,7 @@
 
 # Load data --------------------------------------------------------------------
 ## GADM
-gadm_sp <- readRDS(file.path(data_dir, "gadm36_SYR_1_sp.rds"))
+gadm_sp <- getData('GADM', country='SYR', level=0)
 
 ## Average Annual NTL
 r_2013 <- file.path(data_dir) %>%

--- a/notebooks/ntl-analysis/README.md
+++ b/notebooks/ntl-analysis/README.md
@@ -18,6 +18,16 @@ Code to replicate the analysis can be found [here](https://github.com/datapartne
 
 The main script ([_main.R](https://github.com/datapartnership/syria-economic-monitor/tree/main/notebooks/ntl-analysis/_main.R)) loads all packages and runs all scripts for the analysis. There are separate scripts for processing the data (e.g., [downloading and cleaning Black Marble data](https://github.com/datapartnership/syria-economic-monitor/tree/main/notebooks/ntl-analysis/01_download_black_marble.R)), and separate scripts to produce each of the figures (e.g., [producing maps showing changes in nighttime lights](https://github.com/datapartnership/syria-economic-monitor/tree/main/notebooks/ntl-analysis/02_maps_of_ntl_changes.R)).
 
+Data for the analysis can be downloaded from:
+
+* [Gas Flaring Location Data](https://datacatalog.worldbank.org/search/dataset/0037743)
+
+* __Black Marble Nighttime Lights:__ There are two options to access the data:
+
+  * The code [here](https://github.com/datapartnership/syria-economic-monitor/blob/main/notebooks/ntl-analysis/01_download_black_marble.R) downloads raw data from the [NASA archive](https://ladsweb.modaps.eosdis.nasa.gov/missions-and-measurements/products/VNP46A3/) and processes the data for Syria---mosaicing raster tiles together to cover Syria. Running the code requires a NASA bearer token; the documentation [here](https://github.com/ramarty/download_blackmarble) describes how to obtain a token.
+  
+  * Pre-processed data can be downloaded from [here](https://datacatalog.worldbank.org/int/data/dataset/0063879/syria__night_time_lights), using the __Night Time Lights BlackMarble Data__
+
 ## Findings
 
 The below figure shows nighttime lights from the latest month available. As expected, Syria’s largest cities are the most brightly lit – including Damascus in the southwest and Aleppo in the northwest.

--- a/notebooks/ntl-analysis/_main.R
+++ b/notebooks/ntl-analysis/_main.R
@@ -1,6 +1,13 @@
 # Syria Economic Monitor
 # Nighttime Lights Analysis: Main Script
 
+# PARAMETERS
+# Whether to download and mosaic nighttime light data from the BlackMarble 
+# archive. Instead of re-downloaded and re-processing the data, pre-processed
+# data for Syria can be found here:
+# https://datacatalog.worldbank.org/int/data/dataset/0063879/syria__night_time_lights
+DOWNLOAD_NTL <- F
+
 # Filepaths --------------------------------------------------------------------
 #### Root paths
 if(Sys.info()[["user"]] == "robmarty"){
@@ -44,8 +51,10 @@ RUN_SCRIPTS <- F
 if(RUN_SCRIPTS){
   
   # Download black marble nighttime lights data into monthly rasters 
-  # for Syria
-  source(file.path(ntl_dir, "01_download_black_marble.R"))
+  # for Syria.
+  # NOTE: Requires a bearer token from NASA. To aquire, see documentation here:
+  # https://github.com/ramarty/download_blackmarble
+  if(DOWNLOAD_NTL) source(file.path(ntl_dir, "01_download_black_marble.R"))
   
   # Clean dataset of gas flaring locations; produces a dataset of gas flaring
   # locations in Syria

--- a/notebooks/traffic/README.md
+++ b/notebooks/traffic/README.md
@@ -18,6 +18,8 @@ For further information, please refer to {ref}`foundational_datasets`.
 
 Code to analyze traffic across the three data sources is available [here](https://github.com/datapartnership/syria-economic-monitor/tree/main/notebooks/traffic/traffic_analysis.R).
 
+Data for the analysis can be accessed [here](https://datacatalog.worldbank.org/int/data/dataset/0063878/syrialebanon_border_crossing_traffic).
+
 ## Findings
 
 The below figure shows trends in the traffic indicators from the three sources. VHR images are captured at irregular intervals, so car and truck counts are available at limited points in time. However, comparing the VHR and mobility data emphasizes the downward bias in the mobility data. VHR data shows up to 250 vehicles captured at a single point in time for a border crossing, while mobility data from Outlogic only shows up to 12 unique devices captured during a day. Outlogic data may have too few observations at the border crossing locations to meaningfully observe trends. The traffic index from SAR imagery shows a notable increase in traffic at the Al Abbudiyah border crossing in 2022, a slight upward trend in traffic at the Al Aridah border crossing, and relatively consistent traffic at the Matraba border crossing.


### PR DESCRIPTION
To facilitate reproducibility, added documentation for the NTL and the traffic analysis about where to downloaded the data to run the code -- pointing to links in the DDH